### PR TITLE
feat: adiciona lógica para subir de nível

### DIFF
--- a/BatalhaDePokemons.API/Controllers/PokemonController.cs
+++ b/BatalhaDePokemons.API/Controllers/PokemonController.cs
@@ -132,6 +132,25 @@ public class PokemonController(IPokemonService service) : ControllerBase
     }
     
     /// <summary>
+    /// Adiciona experiencia para um pokemon
+    /// </summary>
+    /// <param name="pokemonId">Guid do pokemon</param>
+    /// <param name="experienciaGanha">Quantidade de xp que será adicionada ao pokemon</param>
+    /// <response code="200">Experiencia adicionada com sucesso</response>
+    /// <response code="404">Pokemon não encontrado</response>
+    /// <response code="400">Erro ao adicionar experiencia</response>
+    [AllowAnonymous]
+    [ProducesResponseType<PokemonResponseDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
+    [HttpPatch("{pokemonId:guid}/adicionarExperiencia")]
+    public async Task<IActionResult> AdicionarExperiencia(Guid pokemonId, ExperienciaDto experienciaGanha)
+    {
+        var pokemon = await service.AdicionarExperienciaAsync(pokemonId, experienciaGanha);
+        return Ok(pokemon);
+    }
+    
+    /// <summary>
     /// Vincula um ataque a um pokemon
     /// </summary>
     /// <param name="pokemonId">Guid do pokemon</param>

--- a/BatalhaDePokemons.API/Program.cs
+++ b/BatalhaDePokemons.API/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddFluentValidationClientsideAdapters();
 builder.Services.AddValidatorsFromAssemblyContaining<AtaqueCreationDtoValidator>();
 builder.Services.AddValidatorsFromAssemblyContaining<PokemonCreationDtoValidator>();
+builder.Services.AddValidatorsFromAssemblyContaining<ExperienciaDtoValidator>();
 
 
 builder.Services.AddEndpointsApiExplorer();

--- a/BatalhaDePokemons.Crosscutting/Constantes/ExceptionMessages.cs
+++ b/BatalhaDePokemons.Crosscutting/Constantes/ExceptionMessages.cs
@@ -39,4 +39,7 @@ public static class ExceptionMessages
 
     public static string PokemonNaoParticipaDaBatalha =>
         "O pokemon não está participando da batalha";
+
+    public static string PokemonNoNivelMaximo(string nome) =>
+        $"O pokemon {nome} já está no nível máximo";
 }

--- a/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/ExperienciaDto.cs
+++ b/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/ExperienciaDto.cs
@@ -1,0 +1,6 @@
+﻿namespace BatalhaDePokemons.Crosscutting.Dtos.Pokemon;
+
+public class ExperienciaDto
+{
+    public int ExperienciaGanha { get; init; }
+}

--- a/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/PokemonCreationDto.cs
+++ b/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/PokemonCreationDto.cs
@@ -3,7 +3,7 @@
 public class PokemonCreationDto
 {
     public string Nome { get; set; }
-    public int Level { get; set; }
+    public int Nivel { get; set; }
     public string Tipo { get; set; }
     public bool IsDesmaiado { get; set; }
     public int PontosDeVida { get; set; }

--- a/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/PokemonResponseDto.cs
+++ b/BatalhaDePokemons.Crosscutting/Dtos/Pokemon/PokemonResponseDto.cs
@@ -6,7 +6,7 @@ public class PokemonResponseDto
 {
     public Guid PokemonId { get; init; }
     public string Nome { get; set; }
-    public  int Level { get; set; }
+    public  int Nivel { get; set; }
     public  int Hp { get; set; }
     public List<AtaqueResponseDto> Ataques { get; set; }
 }

--- a/BatalhaDePokemons.Crosscutting/Exceptions/Pokemon/NivelMaximoException.cs
+++ b/BatalhaDePokemons.Crosscutting/Exceptions/Pokemon/NivelMaximoException.cs
@@ -1,0 +1,3 @@
+﻿namespace BatalhaDePokemons.Crosscutting.Exceptions.Pokemon;
+
+public class NivelMaximoException(string message) : DomainException (message);

--- a/BatalhaDePokemons.Crosscutting/Interfaces/IPokemonService.cs
+++ b/BatalhaDePokemons.Crosscutting/Interfaces/IPokemonService.cs
@@ -12,4 +12,5 @@ public interface IPokemonService
     Task VincularAtaqueAsync(Guid pokemonId, Guid ataqueId);
     Task<List<AtaqueResponseDto>> ObterAtaquesPorPokemonIdAsync(Guid pokemonId);
     Task<PokemonResponseDto> CurarPokemonAsync(Guid pokemonId, int newHp);
+    Task<PokemonResponseDto> AdicionarExperienciaAsync(Guid pokemonId, ExperienciaDto dto);
 }

--- a/BatalhaDePokemons.Crosscutting/SwaggerExamples/PokemonCreationDtoExample.cs
+++ b/BatalhaDePokemons.Crosscutting/SwaggerExamples/PokemonCreationDtoExample.cs
@@ -11,7 +11,7 @@ public class PokemonCreationDtoExample : IExamplesProvider<PokemonCreationDto>
         return new PokemonCreationDto
         {
             Nome = "Charmander",
-            Level = 30,
+            Nivel = 30,
             Tipo = Tipo.Fogo.ToString(),
             IsDesmaiado = false,
             PontosDeVida = 40,

--- a/BatalhaDePokemons.Crosscutting/Validators/ExperienciaDtoValidator.cs
+++ b/BatalhaDePokemons.Crosscutting/Validators/ExperienciaDtoValidator.cs
@@ -1,0 +1,14 @@
+﻿using BatalhaDePokemons.Crosscutting.Constantes;
+using BatalhaDePokemons.Crosscutting.Dtos.Pokemon;
+using FluentValidation;
+
+namespace BatalhaDePokemons.Crosscutting.Validators;
+
+public class ExperienciaDtoValidator : AbstractValidator<ExperienciaDto>
+{
+    public ExperienciaDtoValidator()
+    {
+        RuleFor(x => x.ExperienciaGanha)
+            .GreaterThan(Caracteres.Zero).WithMessage(ValidationErrors.ValorMinimo(Caracteres.Zero));
+    }
+}

--- a/BatalhaDePokemons.Crosscutting/Validators/PokemonCreationDtoValidator.cs
+++ b/BatalhaDePokemons.Crosscutting/Validators/PokemonCreationDtoValidator.cs
@@ -13,7 +13,7 @@ public class PokemonCreationDtoValidator : AbstractValidator<PokemonCreationDto>
             .NotEmpty().WithMessage(ValidationErrors.CampoObrigatorio)
             .MaximumLength(Caracteres.Duzentos).WithMessage(ValidationErrors.TamanhoMaximo(Caracteres.Duzentos));
 
-        RuleFor(x => x.Level)
+        RuleFor(x => x.Nivel)
             .GreaterThan(Caracteres.Zero).WithMessage(ValidationErrors.ValorMinimo(Caracteres.Zero))
             .LessThan(Caracteres.Cem).WithMessage(ValidationErrors.ValorMaximo(Caracteres.Cem));
 

--- a/BatalhaDePokemons.Domain/Mappers/PokemonMapper.cs
+++ b/BatalhaDePokemons.Domain/Mappers/PokemonMapper.cs
@@ -12,7 +12,7 @@ public static class PokemonMapper
         {
             PokemonId = pokemon.PokemonId,
             Nome = pokemon.Nome,
-            Level = pokemon.Nivel,
+            Nivel = pokemon.Nivel,
             Hp = pokemon.Status.PontosDeVida,
             Ataques = pokemon.Ataques?.Select(pa => new AtaqueResponseDto
             {
@@ -29,7 +29,7 @@ public static class PokemonMapper
         return new PokemonCreationDto
         {
             Nome = pokemon.Nome,
-            Level = pokemon.Nivel,
+            Nivel = pokemon.Nivel,
             IsDesmaiado = pokemon.IsDesmaiado,
             PontosDeVida = pokemon.Status.PontosDeVida,
             Ataque = pokemon.Status.Ataque,

--- a/BatalhaDePokemons.Domain/Models/Pokemon.cs
+++ b/BatalhaDePokemons.Domain/Models/Pokemon.cs
@@ -60,11 +60,11 @@ public class Pokemon
 
     public void GanharExperiencia(int experienciaGanha)
     {
+        Experiencia += experienciaGanha;
+        
         if (Nivel >= 100)
             throw new NivelMaximoException(ExceptionMessages.PokemonNoNivelMaximo(Nome));
         
-        Experiencia += experienciaGanha;
-
         while (Experiencia >= ExperienciaParaProximoNivel &&
                Nivel < 100)
         {

--- a/BatalhaDePokemons.Domain/Models/Pokemon.cs
+++ b/BatalhaDePokemons.Domain/Models/Pokemon.cs
@@ -21,6 +21,8 @@ public class Pokemon
     public Guid PokemonId { get; init; } = Guid.NewGuid();
     public string Nome { get; set; }
     public int Nivel { get; set; }
+    public int Experiencia { get; set; }
+    public static int ExperienciaParaProximoNivel => 100;
     public bool IsDesmaiado { get; set; }
     public Tipo Tipo { get; set; }
     public StatusDeCombate Status { get; init; }
@@ -54,6 +56,21 @@ public class Pokemon
     {
         Status.PontosDeVida = newHp;
         IsDesmaiado = false;
+    }
+
+    public void GanharExperiencia(int experienciaGanha)
+    {
+        if (Nivel >= 100)
+            throw new NivelMaximoException(ExceptionMessages.PokemonNoNivelMaximo(Nome));
+        
+        Experiencia += experienciaGanha;
+
+        while (Experiencia >= ExperienciaParaProximoNivel &&
+               Nivel < 100)
+        {
+            Experiencia -= ExperienciaParaProximoNivel;
+            Nivel++;
+        }
     }
 }
 

--- a/BatalhaDePokemons.Domain/Services/PokemonService.cs
+++ b/BatalhaDePokemons.Domain/Services/PokemonService.cs
@@ -18,7 +18,7 @@ public class PokemonService(IPokemonRepository repository, IAtaqueRepository ata
             throw new ArgumentException(ExceptionMessages.TipoInvalido(pokemon.Tipo));
         
         var novoPokemon = new Pokemon(
-            pokemon.Nome, pokemon.Level, tipoConvertido, pokemon.PontosDeVida, pokemon.Velocidade, pokemon.Defesa, pokemon.Ataque);
+            pokemon.Nome, pokemon.Nivel, tipoConvertido, pokemon.PontosDeVida, pokemon.Velocidade, pokemon.Defesa, pokemon.Ataque);
         var novoPokemonId = await repository.AdicionarESalvarAsync(novoPokemon);
         return novoPokemonId;
     }
@@ -49,7 +49,7 @@ public class PokemonService(IPokemonRepository repository, IAtaqueRepository ata
         var pokemonAntigo = await ValidarPokemon(pokemonId);
         
         pokemonAntigo.Nome = pokemon.Nome;
-        pokemonAntigo.Nivel = pokemon.Level;
+        pokemonAntigo.Nivel = pokemon.Nivel;
         pokemonAntigo.Tipo = tipoConvertido;
         pokemonAntigo.IsDesmaiado = pokemon.IsDesmaiado;
         pokemonAntigo.Status.PontosDeVida = pokemon.PontosDeVida;
@@ -100,6 +100,15 @@ public class PokemonService(IPokemonRepository repository, IAtaqueRepository ata
         await repository.AtualizarESalvarAsync(pokemon);
         return PokemonMapper.MapToResponseDto(pokemon);
     }
+
+    public async Task<PokemonResponseDto> AdicionarExperienciaAsync(Guid pokemonId, ExperienciaDto dto)
+    {
+        var pokemon = await ValidarPokemon(pokemonId);
+        pokemon.GanharExperiencia(dto.ExperienciaGanha);
+        var updatedPokemon = await repository.AtualizarESalvarAsync(pokemon);
+        return PokemonMapper.MapToResponseDto(updatedPokemon);
+    }
+    
     private async Task<Pokemon> ValidarPokemon(Guid id)
     {
         var pokemon = await repository.ObterPorIdComAtaquesAsync(id)

--- a/BatalhaDePokemons.Infra/Mappings/PokemonMapping.cs
+++ b/BatalhaDePokemons.Infra/Mappings/PokemonMapping.cs
@@ -38,6 +38,10 @@ public class PokemonMapping : IEntityTypeConfiguration<Pokemon>
                 v => v.ToString(),
                 v => Enum.Parse<Tipo>(v))
             .IsRequired();
+
+        builder.Property(p => p.Experiencia)
+            .HasColumnName(nameof(Pokemon.Experiencia))
+            .HasDefaultValue(0);
         
         builder.OwnsOne(p => p.Status, status =>
         {

--- a/BatalhaDePokemons.Infra/Migrations/20250410164153_AdicionaColunaExperiencia.Designer.cs
+++ b/BatalhaDePokemons.Infra/Migrations/20250410164153_AdicionaColunaExperiencia.Designer.cs
@@ -4,6 +4,7 @@ using BatalhaDePokemons.Infra;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BatalhaDePokemons.Infra.Migrations
 {
     [DbContext(typeof(PokemonsDbContext))]
-    partial class PokemonsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250410164153_AdicionaColunaExperiencia")]
+    partial class AdicionaColunaExperiencia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BatalhaDePokemons.Infra/Migrations/20250410164153_AdicionaColunaExperiencia.cs
+++ b/BatalhaDePokemons.Infra/Migrations/20250410164153_AdicionaColunaExperiencia.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BatalhaDePokemons.Infra.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionaColunaExperiencia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Experiencia",
+                table: "Pokemons",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Experiencia",
+                table: "Pokemons");
+        }
+    }
+}

--- a/BatalhaDePokemons.Test/API/Controllers/PokemonControllerTest.cs
+++ b/BatalhaDePokemons.Test/API/Controllers/PokemonControllerTest.cs
@@ -264,4 +264,48 @@ public class PokemonControllerTest
     }
 
     #endregion
+
+    #region AdicionarExperiencia
+
+    [Fact]
+    public async Task AdicionarExperiencia_QuandoValido_DeveRetornar200Ok()
+    {
+        var pokemon = PokemonBuilder.Novo().Build();
+        var experienciaDto = new ExperienciaDto
+        {
+            ExperienciaGanha = 10,
+        };
+        
+        _pokemonServiceMock.Setup(s => 
+                s.AdicionarExperienciaAsync(It.IsAny<Guid>(), It.IsAny<ExperienciaDto>()))
+                .ReturnsAsync(PokemonMapper.MapToResponseDto(pokemon));
+
+        var result = await _pokemonController.AdicionarExperiencia(pokemon.PokemonId, experienciaDto);
+        
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(200, okResult.StatusCode);
+        var returnedPokemon = Assert.IsType<PokemonResponseDto>(okResult.Value);
+        Assert.Equal(pokemon.Nivel, returnedPokemon.Nivel);
+    }
+
+    [Fact]
+    public async Task AdicionarExperiencia_QuandoPokemonInvalido_DeveRetornar404NotFound()
+    {
+        var pokemon = PokemonBuilder.Novo().Build();
+        var experienciaDto = new ExperienciaDto
+        {
+            ExperienciaGanha = 10
+        };
+        
+        _pokemonServiceMock.Setup(s=>
+            s.AdicionarExperienciaAsync(It.IsAny<Guid>(), It.IsAny<ExperienciaDto>()))
+            .ThrowsAsync(new NotFoundException("Pokemon não encontrado"));
+        
+        var exception = await Assert.ThrowsAsync<NotFoundException>(()=>
+            _pokemonController.AdicionarExperiencia(pokemon.PokemonId, experienciaDto));
+        
+        Assert.Equal("Pokemon não encontrado", exception.Message);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Os pokemons podem passar para o próximo nível (máximo 100) ao atingir uma determinada quantidade de experiência (100). Toda a experiência ganha após atingir o nível máximo deve ser armazenada, mas o pokemon não irá mais subir de nível. A quantidade de experiência não pode ser menor que 0.